### PR TITLE
Add support for --recreate-pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ on the cluster.
 * `replace`: *Optional.* Replace deleted release with same name. (Default: false)
 * `wait_until_ready`: *Optional.* Set to the number of seconds it should wait until all the resources in
     the chart are ready. (Default: `0` which means don't wait).
-
+* `recreate_pods`: *Optional.* This flag will cause all pods to be recreated when upgrading. (Default: false)
 
 
 ## Example

--- a/assets/out
+++ b/assets/out
@@ -27,6 +27,7 @@ wait_until_ready=$(jq -r '.params.wait_until_ready // 0' < $payload)
 debug=$(jq -r '.params.debug // "false"' < $payload)
 replace=$(jq -r '.params.replace // "false"' < $payload)
 delete=$(jq -r '.params.delete // "false"' < $payload)
+recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
 if [ -z "$chart" ]; then
   echo "invalid payload (missing chart)"
   exit 1
@@ -105,6 +106,9 @@ helm_upgrade() {
   fi
   if [ -n "$version" ]; then
     helm_cmd="$helm_cmd --version $version"
+  fi
+  if [ "$recreate_pods" = true ]; then
+    helm_cmd="$helm_cmd --recreate-pods"
   fi
   logfile="/tmp/log"
   mkdir -p /tmp


### PR DESCRIPTION
Added support for Helms `--recreate-pods` flag when running `helm upgrade`, https://github.com/kubernetes/helm/blob/master/docs/using_helm.md#helpful-options-for-installupgraderollback