### PR TITLE
expose --devel flag in params for installing a chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ on the cluster.
 * `version`: *Optional* Chart version to deploy. Only applies if `chart` is not a file.
 * `delete`: *Optional.* Deletes the release instead of installing it. Requires the `name`. (Default: false)
 * `replace`: *Optional.* Replace deleted release with same name. (Default: false)
+* `devel`: *Optional.* Allow development versions of chart to be installed. This is useful when wanting to install pre-release
+  charts (i.e. 1.0.2-rc1) without having to specify a version. (Default: false)
 * `wait_until_ready`: *Optional.* Set to the number of seconds it should wait until all the resources in
     the chart are ready. (Default: `0` which means don't wait).
 * `recreate_pods`: *Optional.* This flag will cause all pods to be recreated when upgrading. (Default: false)

--- a/assets/out
+++ b/assets/out
@@ -27,6 +27,7 @@ wait_until_ready=$(jq -r '.params.wait_until_ready // 0' < $payload)
 debug=$(jq -r '.params.debug // "false"' < $payload)
 replace=$(jq -r '.params.replace // "false"' < $payload)
 delete=$(jq -r '.params.delete // "false"' < $payload)
+devel=$(jq -r '.params.devel // "false"' < $payload)
 override_values=$(jq -r ".params.override_values[]? | if .key and .value then (.key + \"=\" + .value) else empty end"  < $payload)
 override_values_file=$(jq -r ".params.override_values[]? | if .key and .path then (.key + \"=\" + .path) else empty end" < $payload)
 recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
@@ -100,6 +101,9 @@ helm_install() {
   if [ "$debug" = true ]; then
     helm_cmd="$helm_cmd --dry-run --debug"
   fi
+  if [ "$devel" = true ]; then
+    helm_cmd="$helm_cmd --devel"
+  fi
   if [ -n "$version" ]; then
     helm_cmd="$helm_cmd --version $version"
   fi
@@ -129,6 +133,9 @@ helm_upgrade() {
   set_overriden_values
   if [ "$debug" = true ]; then
     helm_cmd="$helm_cmd --dry-run --debug"
+  fi
+  if [ "$devel" = true ]; then
+    helm_cmd="$helm_cmd --devel"
   fi
   if [ -n "$version" ]; then
     helm_cmd="$helm_cmd --version $version"

--- a/test/payload.json.template
+++ b/test/payload.json.template
@@ -11,6 +11,7 @@
     "replace": "true",
     "delete": "false",
     "debug": "false",
+    "devel": "false",
     "wait_until_ready": "10"
   }
 }


### PR DESCRIPTION
allows versions prepended with a hyphen and series of identifiers to be installed without having to also specify the version

when versioning our charts, we sometimes end up with `1.0.2-rc0` and don't want to have to also specify the chart version in the params so it'd be great if we could also set the `--devel` flag when running `helm install/upgrade`.