### PR TITLE
Triage for regression of deployment of chart from directory

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -42,8 +42,8 @@ else
   release=$(jq -r '.source.release // ""' < $payload)
 fi
 
-if [[ "$chart" == *.tgz ]]; then
-  # it's a file
+if [[ "$chart" == *.tgz ]] || [[ -d "$source/$chart" ]]; then
+  # it's a file/directory
   chart_full="$source/$chart"
   version=""
 else


### PR DESCRIPTION
Fixes #19 

Allows for deployments of charts from a directory while a more comprehensive approach is implemented.