### PR TITLE
Cleanup mktemp

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -10,7 +10,7 @@ source /opt/resource/common.sh
 
 # Read inputs
 source=$1
-payload=$(mktemp $TMPDIR/helm-resource-request.XXXXXX)
+payload=$(mktemp helm-resource-request.XXXXXX)
 cat > $payload <&0
 
 # Prepare


### PR DESCRIPTION
While debugging I noticed the payload files weren't being generate in the `/tmp` folder as expected rather in the root of the container E.G. `/helm-helm-resource-request.bAkkA3`.

The manpage for `mktemp` states to use a directory:
```
 -p DIR, --tmpdir[=DIR]
        interpret TEMPLATE relative to DIR; if DIR is not specified, use $TMPDIR if set, else /tmp.  With this option,  TEMPLATE  must  not  be  an
        absolute name; unlike with -t, TEMPLATE may contain slashes, but mktemp creates only the final component
```
so by using `$TMPDIR` which is empty in the container image, the payload files were being forced to the root directory.