### PR TITLE
Hide secret values

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ on the cluster.
 * `values`: *Optional.* File containing the values.yaml for the deployment. Supports setting multiple value files using an array.
 * `override_values`: *Optional.* Array of values that can override those defined in values.yaml. Each entry in
   the array is a map containing a key and a value or path. Value is set directly while path reads the contents of
-  the file in that path.
+  the file in that path. A `hide: true` parameter ensures that the value is not logged and instead replaced with `***HIDDEN***`
 * `version`: *Optional* Chart version to deploy. Only applies if `chart` is not a file.
 * `delete`: *Optional.* Deletes the release instead of installing it. Requires the `name`. (Default: false)
 * `replace`: *Optional.* Replace deleted release with same name. (Default: false)
@@ -93,4 +93,7 @@ jobs:
         value: 2
       - key: version
         path: version/number # Read value from version/number
+      - key: secret
+        value: ((my-top-secret-value)) # Pulled from a credentials backend like Vault
+        hide: true # Hides value in output
 ```

--- a/assets/out
+++ b/assets/out
@@ -85,6 +85,24 @@ set_overriden_values() {
     helm_cmd="$helm_cmd --set '$(echo $overriden_value | base64 -d)'"
     helm_echo="$helm_echo --set '$(echo $overriden_value | base64 -d)'"
   done
+
+  # Get value from given path, but hide the value in the echo
+  for overriden_secret_file in $override_secrets_file; do
+    # Get key and value for each overridden file value
+    key=${overriden_secret_file%%=*}
+    value=${overriden_secret_file#*=}
+    helm_cmd="$helm_cmd --set $key=$(cat $source/$value)"
+    helm_echo="$helm_echo --set $key=***HIDDEN***"
+  done
+
+  # Set value directly, but hide the value in the echo
+  for overriden_secret in $override_secrets; do
+    kv=$(echo $overriden_secret | base64 -d)
+    key=${kv%%=*}
+    value=${kv#*=}
+    helm_cmd="$helm_cmd --set '$kv'"
+    helm_echo="$helm_echo --set '$key=***HIDDEN***'"
+  done
 }
 
 helm_install() {

--- a/assets/out
+++ b/assets/out
@@ -28,8 +28,10 @@ debug=$(jq -r '.params.debug // "false"' < $payload)
 replace=$(jq -r '.params.replace // "false"' < $payload)
 delete=$(jq -r '.params.delete // "false"' < $payload)
 devel=$(jq -r '.params.devel // "false"' < $payload)
-override_values=$(jq -r ".params.override_values[]? | if .key and .value then (.key + \"=\" + .value) else empty end | @base64"  < $payload)
-override_values_file=$(jq -r ".params.override_values[]? | if .key and .path then (.key + \"=\" + .path) else empty end" < $payload)
+override_values=$(jq -r ".params.override_values[]? | if .key and .value and (.hide // false) == false then (.key + \"=\" + .value) else empty end | @base64"  < $payload)
+override_values_file=$(jq -r ".params.override_values[]? | if .key and .path and (.hide // false) == false then (.key + \"=\" + .path) else empty end" < $payload)
+override_secrets=$(jq -r ".params.override_values[]? | if .key and .value and .hide then (.key + \"=\" + .value) else empty end | @base64"  < $payload)
+override_secrets_file=$(jq -r ".params.override_values[]? | if .key and .path and .hide then (.key + \"=\" + .path) else empty end" < $payload)
 recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
 
 if [ -z "$chart" ]; then

--- a/assets/out
+++ b/assets/out
@@ -77,42 +77,53 @@ set_overriden_values() {
     key=${overriden_value_file%%=*}
     value=${overriden_value_file#*=}
     helm_cmd="$helm_cmd --set $key=$(cat $source/$value)"
+    helm_echo="$helm_echo --set $key=$(cat $source/$value)"
   done
 
   # Set value directly
   for overriden_value in $override_values; do
     helm_cmd="$helm_cmd --set '$(echo $overriden_value | base64 -d)'"
+    helm_echo="$helm_echo --set '$(echo $overriden_value | base64 -d)'"
   done
 }
 
 helm_install() {
   helm_cmd="helm install"
+  helm_echo="helm install"
   helm_cmd="$helm_cmd --namespace $namespace"
+  helm_echo="$helm_echo --namespace $namespace"
   if [ -n "$release" ]; then
     helm_cmd="$helm_cmd -n $release"
+    helm_echo="$helm_echo -n $release"
   fi
   if [ -n "$values" ]; then
     for value in $values; do
       helm_cmd="$helm_cmd -f $source/$value"
+      helm_echo="$helm_echo -f $source/$value"
     done
   fi
   set_overriden_values
   if [ "$replace" = true ]; then
     helm_cmd="$helm_cmd --replace"
+    helm_echo="$helm_echo --replace"
   fi
   if [ "$debug" = true ]; then
     helm_cmd="$helm_cmd --dry-run --debug"
+    helm_echo="$helm_echo --dry-run --debug"
   fi
   if [ "$devel" = true ]; then
     helm_cmd="$helm_cmd --devel"
+    helm_echo="$helm_echo --devel"
   fi
   if [ -n "$version" ]; then
     helm_cmd="$helm_cmd --version $version"
+    helm_echo="$helm_echo --version $version"
   fi
   logfile="/tmp/log"
   mkdir -p /tmp
   helm_cmd="$helm_cmd $chart_full | tee $logfile"
-  echo "Running command $helm_cmd"
+  helm_echo="$helm_echo $chart_full | tee $logfile"
+  echo "Running command $helm_echo"
   eval $helm_cmd
 
   # Find the name of the release
@@ -127,28 +138,35 @@ current_revision() {
 
 helm_upgrade() {
   helm_cmd="helm upgrade $release"
+  helm_echo="helm upgrade $release"
   if [ -n "$values" ]; then
     for value in $values; do
       helm_cmd="$helm_cmd -f $source/$value"
+      helm_echo="$helm_echo -f $source/$value"
     done
   fi
   set_overriden_values
   if [ "$debug" = true ]; then
     helm_cmd="$helm_cmd --dry-run --debug"
+    helm_echo="$helm_echo --dry-run --debug"
   fi
   if [ "$devel" = true ]; then
     helm_cmd="$helm_cmd --devel"
+    helm_echo="$helm_echo --devel"
   fi
   if [ -n "$version" ]; then
     helm_cmd="$helm_cmd --version $version"
+    helm_echo="$helm_echo --version $version"
   fi
   if [ "$recreate_pods" = true ]; then
     helm_cmd="$helm_cmd --recreate-pods"
+    helm_echo="$helm_echo --recreate-pods"
   fi
   logfile="/tmp/log"
   mkdir -p /tmp
   helm_cmd="$helm_cmd $chart_full | tee $logfile"
-  echo "Running command $helm_cmd"
+  helm_echo="$helm_echo $chart_full | tee $logfile"
+  echo "Running command $helm_echo"
   eval $helm_cmd
 }
 
@@ -159,13 +177,16 @@ helm_delete() {
   fi
   echo "Deleting the release $release..."
   helm_cmd="helm delete"
+  helm_echo="helm delete"
   if [ "$debug" = true ]; then
     helm_cmd="$helm_cmd --dry-run --debug"
+    helm_echo="$helm_echo --dry-run --debug"
   fi
   logfile="/tmp/log"
   mkdir -p /tmp
   helm_cmd="$helm_cmd $release | tee $logfile"
-  echo "Running command $helm_cmd"
+  helm_echo="$helm_echo $release | tee $logfile"
+  echo "Running command $helm_echo"
   eval $helm_cmd
 }
 


### PR DESCRIPTION
Fixes #24 

A quick attempt to hide secret values from the log when putting a chart resource.
It just duplicates the `helm_cmd` variable into `helm_echo`, and adds `***HIDDEN***` in place of the real value if the `hide` parameter is set to `true` for each key in the `override_values` list.