### PR TITLE
Remove the cluster-info call

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -43,7 +43,6 @@ setup_kubernetes() {
   fi
 
   kubectl config use-context default
-  kubectl cluster-info
   kubectl version
 }
 


### PR DESCRIPTION
When using the concourse-helm-resource with a service account with the minimum privileges as per https://github.com/kubernetes/helm/blob/master/docs/rbac.md#example-deploy-helm-in-a-namespace-talking-to-tiller-in-another-namespace and http://technosophos.com/2017/11/20/securing-helm.html the cluster-info command fails. It seems that cluster-info isn't really necessary.

Since the version bump of kubectl from `1.8.4` to `1.9.6` an error is returned due to insufficient permissions: 

```
Initializing kubectl...
Cluster "default" set.
User "admin" set.
Context "default" created.
Switched to context "default".
Kubernetes master is running at https://myk8smaster

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
Error from server (Forbidden): services is forbidden: User "system:serviceaccount:my-test-namespace:concourse-deploy" cannot list services in the namespace "kube-system"
```

 the service account has a role that has the following permissions: 
```
  - verbs:
      - create
    apiGroups:
      - ''
    resources:
      - pods/portforward
  - verbs:
      - list
    apiGroups:
      - ''
    resources:
      - pods
```


I suggest removing this call to encourage the use of the principal of least privilege. 