### PR TITLE
`out` correctly gets new release version

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -93,8 +93,7 @@ set_overriden_values() {
 
 # Find the current revision of a helm release
 current_revision() {
-  revision=`helm status --tiller-namespace $tiller_namespace $release | grep "DEPLOYED" | awk '{print $1}'`
-  echo $revision
+  helm history --tiller-namespace $tiller_namespace $release | grep "DEPLOYED" | awk '{ print $1 }'
 }
 
 helm_upgrade() {


### PR DESCRIPTION
`helm status` doesn't show the version, so I think this hasn't worked
since switching from `helm history`. The previous churn around this was
to avoid an issue with gPRC max message sizes, which has been fixed in
Helm 2.8.2, and which is now used by this project.