### PR TITLE
`out` accepts `kubeconfig_path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ on the cluster.
 * `wait_until_ready`: *Optional.* Set to the number of seconds it should wait until all the resources in
     the chart are ready. (Default: `0` which means don't wait).
 * `recreate_pods`: *Optional.* This flag will cause all pods to be recreated when upgrading. (Default: false)
+* `kubeconfig_path`: *Optional.* File containing a kubeconfig. Overrides source configuration for cluster, token, and admin config.
 
 ## Example
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -4,45 +4,54 @@ set -e
 setup_kubernetes() {
   payload=$1
   source=$2
-  # Setup kubectl
-  cluster_url=$(jq -r '.source.cluster_url // ""' < $payload)
-  if [ -z "$cluster_url" ]; then
-    echo "invalid payload (missing cluster_url)"
-    exit 1
-  fi
-  if [[ "$cluster_url" =~ https.* ]]; then
 
-    cluster_ca=$(jq -r '.source.cluster_ca // ""' < $payload)
-    admin_key=$(jq -r '.source.admin_key // ""' < $payload)
-    admin_cert=$(jq -r '.source.admin_cert // ""' < $payload)
-    token=$(jq -r '.source.token // ""' < $payload)
-    token_path=$(jq -r '.params.token_path // ""' < $payload)
-
+  kubeconfig_path=$(jq -r '.params.kubeconfig_path // ""' < $payload)
+  absolute_kubeconfig_path="${source}/${kubeconfig_path}"
+  if [ -f "$absolute_kubeconfig_path" ]; then
     mkdir -p /root/.kube
+    cp "$absolute_kubeconfig_path" "/root/.kube/config"
+  else
+    # Setup kubectl
+    cluster_url=$(jq -r '.source.cluster_url // ""' < $payload)
+    if [ -z "$cluster_url" ]; then
+      echo "invalid payload (missing cluster_url)"
+      exit 1
+    fi
+    if [[ "$cluster_url" =~ https.* ]]; then
 
-    ca_path="/root/.kube/ca.pem"
-    echo "$cluster_ca" | base64 -d > $ca_path
-    kubectl config set-cluster default --server=$cluster_url --certificate-authority=$ca_path
+      cluster_ca=$(jq -r '.source.cluster_ca // ""' < $payload)
+      admin_key=$(jq -r '.source.admin_key // ""' < $payload)
+      admin_cert=$(jq -r '.source.admin_cert // ""' < $payload)
+      token=$(jq -r '.source.token // ""' < $payload)
+      token_path=$(jq -r '.params.token_path // ""' < $payload)
 
-    if [ -f "$source/$token_path" ]; then
-      kubectl config set-credentials admin --token=$(cat $source/$token_path)
-    elif [ ! -z "$token" ]; then
-      kubectl config set-credentials admin --token=$token
+      mkdir -p /root/.kube
+
+      ca_path="/root/.kube/ca.pem"
+      echo "$cluster_ca" | base64 -d > $ca_path
+      kubectl config set-cluster default --server=$cluster_url --certificate-authority=$ca_path
+
+      if [ -f "$source/$token_path" ]; then
+        kubectl config set-credentials admin --token=$(cat $source/$token_path)
+      elif [ ! -z "$token" ]; then
+        kubectl config set-credentials admin --token=$token
+      else
+        key_path="/root/.kube/key.pem"
+        cert_path="/root/.kube/cert.pem"
+        echo "$admin_key" | base64 -d > $key_path
+        echo "$admin_cert" | base64 -d > $cert_path
+        kubectl config set-credentials admin --client-certificate=$cert_path --client-key=$key_path
+      fi
+
+      kubectl config set-context default --cluster=default --user=admin
     else
-      key_path="/root/.kube/key.pem"
-      cert_path="/root/.kube/cert.pem"
-      echo "$admin_key" | base64 -d > $key_path
-      echo "$admin_cert" | base64 -d > $cert_path
-      kubectl config set-credentials admin --client-certificate=$cert_path --client-key=$key_path
+      kubectl config set-cluster default --server=$cluster_url
+      kubectl config set-context default --cluster=default
     fi
 
-    kubectl config set-context default --cluster=default --user=admin
-  else
-    kubectl config set-cluster default --server=$cluster_url
-    kubectl config set-context default --cluster=default
+    kubectl config use-context default
   fi
 
-  kubectl config use-context default
   kubectl version
 }
 


### PR DESCRIPTION
This supports the usecase where a kubeconfig is not known at
`set-pipeline` time, but is instead dynamically created during the
execution of a pipeline.

Note: It's not currently possible to provide the same parameter to
`check` containers, so the `check` step will not work for resources
using this parameter.

resolves #36