### PR TITLE
Add helm_host source configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ resource_types:
 * `tiller_namespace`: *Optional.* Kubernetes namespace where tiller is running (or will be installed to). (Default: kube-system)
 * `tiller_service_account`: *Optional* Name of the service account that tiller will use (only applies if helm_init_server is true).
 * `repos`: *Optional.* Array of Helm repositories to initialize, each repository is defined as an object with `name` and `url` properties.
+* `helm_host`: *Optional* Address of Tiller. Skips helm discovery process. (only applies if `helm_init_server` is false).
 
 ## Behavior
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -55,6 +55,7 @@ setup_helm() {
     helm init --tiller-namespace=$tiller_namespace --service-account=$tiller_service_account --upgrade
     wait_for_service_up tiller-deploy 10
   else
+    export HELM_HOST=$(jq -r '.source.helm_host // ""' < $1)
     helm init -c --tiller-namespace $tiller_namespace > /dev/null
   fi
 


### PR DESCRIPTION
Allows passing a value to set the `HELM_HOST` environment variable.

This makes Helm skip creating a port forwarder tunnel to Tiller.

See https://github.com/linkyard/concourse-helm-resource/issues/45