### PR TITLE
Add support for username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ resource_types:
 * `helm_init_server`: *Optional.* Installs helm into the cluster if not already installed. (Default: false)
 * `tiller_namespace`: *Optional.* Kubernetes namespace where tiller is running (or will be installed to). (Default: kube-system)
 * `tiller_service_account`: *Optional* Name of the service account that tiller will use (only applies if helm_init_server is true).
-* `repos`: *Optional.* Array of Helm repositories to initialize, each repository is defined as an object with `name` and `url` properties.
+* `repos`: *Optional.* Array of Helm repositories to initialize, each repository is defined as an object with properties `name`, `url` (required) username and password (optional).
 * `helm_host`: *Optional* Address of Tiller. Skips helm discovery process. (only applies if `helm_init_server` is false).
 
 ## Behavior


### PR DESCRIPTION
Helm 2.9 adds support for basic auth. This commit adds support for the
new flag when setting repos.

Also removes the need for `cut`, using `jq` instead.

Closes #52