### PR TITLE
Update Helm to 2.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM linkyard/docker-helm:2.8.2
+FROM linkyard/docker-helm:2.9.0
 LABEL maintainer "mario.siegenthaler@linkyard.ch"
 
 RUN apk add --update --upgrade --no-cache jq bash nodejs curl yarn


### PR DESCRIPTION
Blocked by linkyard/docker-helm#9