### PR TITLE
Add namespace to job params

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ on the cluster.
 #### Parameters
 
 * `chart`: *Required.* Either the file containing the helm chart to deploy (ends with .tgz) or the name of the chart (e.g. `stable/mysql`).
+* `namespace`: *Optional.* Either a file containing the name of the namespace or the name of the namespace. (Default: taken from source configuration).
 * `release`: *Optional.* Either a file containing the name of the release or the name of the release. (Default: taken from source configuration).
 * `values`: *Optional.* File containing the values.yaml for the deployment. Supports setting multiple value files using an array.
 * `override_values`: *Optional.* Array of values that can override those defined in values.yaml. Each entry in

--- a/assets/out
+++ b/assets/out
@@ -22,6 +22,7 @@ namespace=$(jq -r '.source.namespace // "default"' < $payload)
 tiller_namespace=$(jq -r '.source.tiller_namespace // "kube-system"' < $payload)
 chart=$(jq -r '.params.chart // ""' < $payload)
 version=$(jq -r '.params.version // ""' < $payload)
+namespace_file=$(jq -r '.params.namespace // ""' < $payload)
 release_file=$(jq -r '.params.release // ""' < $payload)
 values=$(jq -r '.params.values // "" | if type == "array" then .[] else . end' < $payload)
 wait_until_ready=$(jq -r '.params.wait_until_ready // 0' < $payload)
@@ -41,6 +42,13 @@ if [ -z "$chart" ]; then
   echo "invalid payload (missing chart)"
   exit 1
 fi
+
+if [ -f "$namespace_file" ]; then
+  namespace=`cat $source/$namespace_file`
+elif [ -n "$namespace_file" ]; then
+  namespace=$namespace_file
+fi
+
 if [ -n "$release_file" ]; then
   if [ -f "$release_file" ]; then
     release=`cat $source/$release_file`


### PR DESCRIPTION
Adds the ability to configure a namespace in the same way we configure
releases, per job.

Closes #55