### PR TITLE
fix: detection if 'params.release' and 'params.namespace' are files

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -44,14 +44,14 @@ if [ -z "$chart" ]; then
   exit 1
 fi
 
-if [ -f "$namespace_file" ]; then
+if [ -f "$source/$namespace_file" ]; then
   namespace=`cat $source/$namespace_file`
 elif [ -n "$namespace_file" ]; then
   namespace=$namespace_file
 fi
 
 if [ -n "$release_file" ]; then
-  if [ -f "$release_file" ]; then
+  if [ -f "$source/$release_file" ]; then
     release=`cat $source/$release_file`
   else
     release=$release_file


### PR DESCRIPTION
Currently anything one passes as `params.release` or `params.namespace` are interpreted as literal release or namespace names, even if they're invalid names (eg. with directory separators in them) and a file with that name exists.

Apparently it was https://github.com/linkyard/concourse-helm-resource/pull/50 broke the ability to pass a filename for `params.release`.