### PR TITLE
`helm diff` supports new releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer "mario.siegenthaler@linkyard.ch"
 
 RUN apk add --update --upgrade --no-cache jq bash nodejs curl yarn
 
-ENV KUBERNETES_VERSION 1.9.6
+ARG KUBERNETES_VERSION=1.10.4
 RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl; \
     chmod +x /usr/local/bin/kubectl
 

--- a/assets/out
+++ b/assets/out
@@ -152,7 +152,7 @@ helm_upgrade() {
 
   helm_args=("${upgrade_args[@]}" "${overridden_args[@]}" "${non_diff_args[@]}")
   helm_echo_args=("${upgrade_args[@]}" "${scrubbed_overridden_args[@]}" "${non_diff_args[@]}")
-  helm_diff_args=("${upgrade_args[@]}" "${overridden_args[@]}" "--suppress-secrets")
+  helm_diff_args=("${upgrade_args[@]}" "${overridden_args[@]}" "--suppress-secrets" "--allow-unreleased")
   if [ "$show_diff" = true ] && current_revision > /dev/null && [ "$devel" != true ]; then
     if [ "$tls_enabled" = true ]; then
       echo "helm diff does not support TLS at the present moment."


### PR DESCRIPTION
helm diff v2.9.0+2 adds the `--allow-unreleased` flag which shows the full helm release as a diff if the release is brand new. Without this flag, helm diff errors. Currently, the workaround is to not provide the `helm_diff: true` parameter during the first `put` and to only add it later.

Also change the Dockerfile so take KUBERNETES_VERSION as a build-time ARG, and bump it to the latest release (1.10.4).