### PR TITLE
Add option to exit after *helm diff*

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ on the cluster.
     the chart are ready. (Default: `0` which means don't wait).
 * `recreate_pods`: *Optional.* This flag will cause all pods to be recreated when upgrading. (Default: false)
 * `show_diff`: *Optional.* Show the diff that is applied if upgrading an existing successful release. Will not be used when `devel` is set. (Default: false)
+* `exit_after_diff`: *Optional.* Show the diff but don't actually install/upgrade. (Default: false)
 
 ## Example
 

--- a/assets/out
+++ b/assets/out
@@ -39,6 +39,7 @@ override_secrets=$(jq -r ".params.override_values[]? | if .key and .value and .h
 override_secrets_file=$(jq -r ".params.override_values[]? | if .key and .path and .hide then (.key + \"=\" + .path) else empty end" < $payload)
 recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
 tls_enabled=$(jq -r '.source.tls_enabled // "false"' < $payload)
+exit_after_diff=$(jq -r '.params.exit_after_diff // "false"' < $payload)
 
 if [ -z "$chart" ]; then
   echo "invalid payload (missing chart)"
@@ -162,8 +163,12 @@ helm_upgrade() {
     fi
   fi
 
-  echo "Running command helm ${helm_echo_args[@]} | tee $logfile"
-  helm "${helm_args[@]}" $tls_flag | tee "$logfile"
+  if [ "$exit_after_diff" = true ]; then
+    echo "Exiting after diff"
+  else
+    echo "Running command helm ${helm_echo_args[@]} | tee $logfile"
+    helm "${helm_args[@]}" $tls_flag | tee "$logfile"
+  fi
 }
 
 helm_delete() {


### PR DESCRIPTION
Running `debug` is way too mistaking. To fully use the power of `helm diff`, I've added a flag to exit before the helm install/upgrade to get the diff without going the actually deployment. It forces you to have 2 JOBS one with the new flag and one without but at least you can gate what you deploy.