### PR TITLE
Allow setting values as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ on the cluster.
 * `values`: *Optional.* File containing the values.yaml for the deployment. Supports setting multiple value files using an array.
 * `override_values`: *Optional.* Array of values that can override those defined in values.yaml. Each entry in
   the array is a map containing a key and a value or path. Value is set directly while path reads the contents of
-  the file in that path. A `hide: true` parameter ensures that the value is not logged and instead replaced with `***HIDDEN***`
+  the file in that path. A `hide: true` parameter ensures that the value is not logged and instead replaced with `***HIDDEN***`.
+  A `type: string` parameter makes sure Helm always treats the value as a string (uses the `--set-string` option to Helm; useful if the value varies
+  and may look like a number, eg. if it's a Git commit hash).
 * `version`: *Optional* Chart version to deploy, can be a file or a value. Only applies if `chart` is not a file.
 * `delete`: *Optional.* Deletes the release instead of installing it. Requires the `name`. (Default: false)
 * `replace`: *Optional.* Replace deleted release with same name. (Default: false)
@@ -108,4 +110,7 @@ jobs:
       - key: secret
         value: ((my-top-secret-value)) # Pulled from a credentials backend like Vault
         hide: true # Hides value in output
+      - key: image.tag
+        path: version/image_tag # Read value from version/number
+        type: string            # Make sure it's interpreted as a string by Helm (not a number)
 ```

--- a/assets/out
+++ b/assets/out
@@ -71,7 +71,7 @@ if [ "$tls_enabled" = true ]; then
 fi
 
 set_overridden_values() {
-  while read -r -d '' key && read -r -d '' value && read -r -d '' path && read -r -d '' hidden; do
+  while read -r -d '' key && read -r -d '' value && read -r -d '' path && read -r -d '' hidden && read -r -d '' type; do
     if [ -n "$path" ]; then
       value="$(< "$source/$path")"
     fi
@@ -81,9 +81,14 @@ set_overridden_values() {
       scrubbed_value='***HIDDEN***'
     fi
 
-    overridden_args+=(--set "$key=$value")
-    scrubbed_overridden_args+=(--set "$key=$scrubbed_value")
-  done < <(jq -j '.params.override_values[]? | if .key and (.value or .path) then (.key, .value // "", .path // "", .hidden // false) else empty end | tostring + "\u0000"'  < $payload)
+    helm_set_opt='--set'
+    if [ "$type" == 'string' ]; then
+      helm_set_opt='--set-string'
+    fi
+
+    overridden_args+=("$helm_set_opt" "$key=$value")
+    scrubbed_overridden_args+=("$helm_set_opt" "$key=$scrubbed_value")
+  done < <(jq -j '.params.override_values[]? | if .key and (.value or .path) then (.key, .value // "", .path // "", .hidden // false, .type) else empty end | tostring + "\u0000"'  < $payload)
 }
 
 # Find the current revision of a helm release

--- a/assets/out
+++ b/assets/out
@@ -33,10 +33,6 @@ devel=$(jq -r '.params.devel // "false"' < $payload)
 recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
 force=$(jq -r '.params.force // "false"' < $payload)
 show_diff=$(jq -r '.params.show_diff // "false"' < $payload)
-override_values=$(jq -r ".params.override_values[]? | if .key and .value and (.hide // false) == false then (.key + \"=\" + .value) else empty end | @base64"  < $payload)
-override_values_file=$(jq -r ".params.override_values[]? | if .key and .path and (.hide // false) == false then (.key + \"=\" + .path) else empty end" < $payload)
-override_secrets=$(jq -r ".params.override_values[]? | if .key and .value and .hide then (.key + \"=\" + .value) else empty end | @base64"  < $payload)
-override_secrets_file=$(jq -r ".params.override_values[]? | if .key and .path and .hide then (.key + \"=\" + .path) else empty end" < $payload)
 recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
 tls_enabled=$(jq -r '.source.tls_enabled // "false"' < $payload)
 
@@ -75,38 +71,19 @@ if [ "$tls_enabled" = true ]; then
 fi
 
 set_overridden_values() {
-  # Get value from given path
-  for overridden_value_file in $override_values_file; do
-    # Get key and value for each overridden file value
-    key=${overridden_value_file%%=*}
-    value=${overridden_value_file#*=}
-    overridden_args+=("--set" "$key=$(cat $source/$value)")
-    scrubbed_overridden_args+=("--set" "$key=$(cat $source/$value)")
-  done
+  while read -r -d '' key && read -r -d '' value && read -r -d '' path && read -r -d '' hidden; do
+    if [ -n "$path" ]; then
+      value="$(< "$source/$path")"
+    fi
 
-  # Set value directly
-  for overridden_value in $override_values; do
-    overridden_args+=("--set" "$(echo $overridden_value | base64 -d)")
-    scrubbed_overridden_args+=("--set" "$(echo $overridden_value | base64 -d)")
-  done
+    scrubbed_value="$value"
+    if [ "$hidden" != 'false' ]; then
+      scrubbed_value='***HIDDEN***'
+    fi
 
-  # Get value from given path, but hide the value in the echo
-  for overridden_secret_file in $override_secrets_file; do
-    # Get key and value for each overridden file value
-    key=${overridden_secret_file%%=*}
-    value=${overridden_secret_file#*=}
-    overridden_args+=("--set" "$key=$(cat $source/$value)")
-    scrubbed_overridden_args+=("--set" "$key=***HIDDEN***")
-  done
-
-  # Set value directly, but hide the value in the echo
-  for overridden_secret in $override_secrets; do
-    kv=$(echo $overridden_secret | base64 -d)
-    key=${kv%%=*}
-    value=${kv#*=}
-    overridden_args+=("--set" "$kv")
-    scrubbed_overridden_args+=("--set" "$key=***HIDDEN***")
-  done
+    overridden_args+=(--set "$key=$value")
+    scrubbed_overridden_args+=(--set "$key=$scrubbed_value")
+  done < <(jq -j '.params.override_values[]? | if .key and (.value or .path) then (.key, .value // "", .path // "", .hidden // false) else empty end | tostring + "\u0000"'  < $payload)
 }
 
 # Find the current revision of a helm release


### PR DESCRIPTION
This PR adds support for a `type: string` parameter in `override_values`. This parameter makes the resource use the `--set-string` option of Helm (instead of the `--set` option) for the given value override. It can be used to ensure that Helm always treats the value as a string, useful if the value varies and may look like a number, eg. if it's a Git commit hash. See also https://github.com/kubernetes/helm/issues/1707