### PR TITLE
Updates helm to v2.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM linkyard/docker-helm:2.9.1
+FROM linkyard/docker-helm:2.10.0
 LABEL maintainer "mario.siegenthaler@linkyard.ch"
 
 RUN apk add --update --upgrade --no-cache jq bash nodejs curl yarn


### PR DESCRIPTION
Use the latest `linkyard/docker-helm` image: https://github.com/linkyard/docker-helm/releases/tag/2.10.0 