### PR TITLE
Update repositories once

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -142,8 +142,9 @@ setup_repos() {
     else
       helm repo add $name $url --tiller-namespace $tiller_namespace
     fi
-    helm repo update
   done
+
+  helm repo update
 }
 
 setup_resource() {


### PR DESCRIPTION
Instead of calling `helm repo update` for each repo, do it once at the
end of the setup / init process.