### PR TITLE
set tiller-namespace in check script

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -19,6 +19,7 @@ echo "Resource setup successful."
 # Parse parameters
 namespace=$(jq -r '.source.namespace // "default"' < $payload)
 release=$(jq -r '.source.release // ""' < $payload)
+tiller_namespace=$(jq -r '.source.tiller_namespace // "kube-system"' < $payload)
 
 current_release=$(jq -r '.version.release' < $payload || true)
 if [ -z "$release" ]; then
@@ -34,13 +35,13 @@ current_rev=$(jq -r '.version.revision // "0"' < $payload || true)
 
 if [ "$current_rev" -eq "0" ]; then
   # Empty => return the current
-  helm history $release $tls_flag | tail -n 1 | while read -r line; do
+  helm history $release $tls_flag --tiller-namespace $tiller_namespace | tail -n 1 | while read -r line; do
     revision=$(echo $line | awk '{ print $1 }')
     echo "$revision"
   done | jq -R '.' | jq -s "map({\"revision\": ., \"release\": \"$release\"})" >&3
 else
   # All versions equal and newer
-  helm history $release $tls_flag | tail -n +2 | while read -r line; do
+  helm history $release $tls_flag --tiller-namespace $tiller_namespace | tail -n +2 | while read -r line; do
     revision=$(echo $line | awk '{ print $1 }')
     if [ -z "$current_rev" ] || [ "$revision" -ge "$current_rev" ]; then
       echo "$revision"


### PR DESCRIPTION
We are currently seeing the following on any of our jobs with this resource

```
Resource setup successful.
Error: could not find tiller
```
Pulling in the `.source.tiller_namespace` looks to solve the issue and brings the script up-to-date with the others.