### PR TITLE
Fix listing of big historys in check

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -35,13 +35,13 @@ current_rev=$(jq -r '.version.revision // "0"' < $payload || true)
 
 if [ "$current_rev" -eq "0" ]; then
   # Empty => return the current
-  helm history $release $tls_flag --tiller-namespace $tiller_namespace | tail -n 1 | while read -r line; do
+  helm history $tls_flag --tiller-namespace $tiller_namespace --max 20 $release | tail -n 1 | while read -r line; do
     revision=$(echo $line | awk '{ print $1 }')
     echo "$revision"
   done | jq -R '.' | jq -s "map({\"revision\": ., \"release\": \"$release\"})" >&3
 else
   # All versions equal and newer
-  helm history $release $tls_flag --tiller-namespace $tiller_namespace | tail -n +2 | while read -r line; do
+  helm history $tls_flag --tiller-namespace $tiller_namespace  --max 20 $release | tail -n +2 | while read -r line; do
     revision=$(echo $line | awk '{ print $1 }')
     if [ -z "$current_rev" ] || [ "$revision" -ge "$current_rev" ]; then
       echo "$revision"


### PR DESCRIPTION
We have a release with more then 256 deployments and run into this error:

```
Error: grpc: trying to send message larger than max (25314892 vs. 20971520)
```

This fixes check for the resource