### PR TITLE
Updating to helm 2.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM linkyard/docker-helm:2.11.0
+FROM linkyard/docker-helm:2.12.2
 LABEL maintainer "mario.siegenthaler@linkyard.ch"
 
 RUN apk add --update --upgrade --no-cache jq bash curl
 
-ARG KUBERNETES_VERSION=1.11.3
+ARG KUBERNETES_VERSION=1.11.6
 RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl; \
     chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
Now that `linkyard/docker-helm:2.12.2` is available (from linkyard/docker-helm#19), it'd be good to bump up the resource 😁

I also bumped the kubectl version to the latest patch.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>