### PR TITLE
feat: Enable pool kubeconfig pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ resource_types:
 
 ## Source Configuration
 
-* `cluster_url`: *Required.* URL to Kubernetes Master API service
+* `cluster_url`: *Optional.* URL to Kubernetes Master API service. Do not set when using the `kubeconfig_path` parameter, otherwise required.
 * `cluster_ca`: *Optional.* Base64 encoded PEM. Required if `cluster_url` is https.
 * `token`: *Optional.* Bearer token for Kubernetes.  This, 'token_path' or `admin_key`/`admin_cert` are required if `cluster_url` is https.
 * `token_path`: *Optional.* Path to file containing the bearer token for Kubernetes.  This, 'token' or `admin_key`/`admin_cert` are required if `cluster_url` is https.
@@ -39,12 +39,17 @@ resource_types:
 * `repos`: *Optional.* Array of Helm repositories to initialize, each repository is defined as an object with properties `name`, `url` (required) username and password (optional).
 * `plugins`: *Optional.* Array of Helm plugins to install, each defined as an object with properties `url` (required), `version` (optional).
 * `stable_repo`: *Optional* Override default Helm stable repo <https://kubernetes-charts.storage.googleapis.com>. Useful if running helm deploys without internet access.
+* `kubeconfig_namespace`: *Optional.* Use the kubeconfig context namespace as the helm namespace. (Default: false)
+* `kubeconfig_tiller_namespace`: *Optional.* Use the kubeconfig context namespace as the tiller namespace. (Default: false)
+* `tracing_enabled`: *Optional.* Enable extremely verbose tracing for this resource. Useful when developing the resource itself. May allow secrets to be displayed. (Default: false)
+* `helm_init_wait`: *Optional.* When initializing the helm server, use the `--wait` option. (Default: false)
+* `helm_setup_purge_all`: *Optional.* Delete and purge every helm release. Use with extreme caution. (Default: false)
 
 ## Behavior
 
 ### `check`: Check for new releases
 
-Any new revisions to the release are returned, no matter their current state. The release must be specified in the
+Any new revisions to the release are returned, no matter their current state. The release and cluster url must be specified in the
 source for `check` to work.
 
 ### `in`: Not Supported
@@ -83,6 +88,7 @@ on the cluster.
 * `exit_after_diff`: *Optional.* Show the diff but don't actually install/upgrade. (Default: false)
 * `reuse_values`: *Optional.* When upgrading, reuse the last release's values. (Default: false)
 * `wait`: *Optional.* Allows deploy task to sleep for X seconds before continuing to next task. Allows pods to restart and become stable, useful where dependency between pods exists. (Default: 0)
+* `kubeconfig_path`: *Optional.* File containing a kubeconfig. Overrides source configuration for cluster, token, and admin config.
 
 ## Example
 

--- a/assets/check
+++ b/assets/check
@@ -12,14 +12,11 @@ source /opt/resource/common.sh
 payload=$(mktemp $TMPDIR/helm-resource-request.XXXXXX)
 cat > $payload <&0
 
-# Prepare
-setup_resource $payload
-echo "Resource setup successful."
-
 # Parse parameters
 namespace=$(jq -r '.source.namespace // "default"' < $payload)
 release=$(jq -r '.source.release // ""' < $payload)
 tiller_namespace=$(jq -r '.source.tiller_namespace // "kube-system"' < $payload)
+cluster_url=$(jq -r '.source.cluster_url // ""' < $payload)
 
 tillerless=$(jq -r '.source.tillerless // "false"' < $payload)
 if [ "$tillerless" = true ]; then
@@ -39,6 +36,27 @@ if [ "$tls_enabled" = true ]; then
 fi
 
 current_rev=$(jq -r '.version.revision // "0"' < $payload || true)
+
+if [ -z "$cluster_url" ]; then
+  # Since the resource was configured to use a dynamic namespace,
+  # check does not make any sense since it is impossible to know which
+  # tiller and which release name should be checked.
+  # The resource is in "put" only mode.
+  if [ $current_rev -eq 0 ]; then
+    # When there was no `version` passed in, return an empty list
+    echo '[]' >&3
+  else
+    # When the `version` was passed in, parrot it back
+    printf '[{"revision":"%s","release":"%s"}]\n' "$current_rev" "$release" | jq -M . >&3
+  fi
+
+  # Check has successfully finished so exit with success.
+  exit 0
+fi
+
+# Prepare
+setup_resource $payload
+echo "Resource setup successful."
 
 if [ "$current_rev" -eq "0" ]; then
   # Empty => return the current

--- a/assets/out
+++ b/assets/out
@@ -20,7 +20,6 @@ echo "Resource setup successful."
 # Parse parameters
 tillerless=$(jq -r '.source.tillerless // "false"' < $payload)
 namespace=$(jq -r '.source.namespace // "default"' < $payload)
-tiller_namespace=$(jq -r '.source.tiller_namespace // "kube-system"' < $payload)
 chart=$(jq -r '.params.chart // ""' < $payload)
 version=$(jq -r '.params.version // ""' < $payload)
 namespace_file=$(jq -r '.params.namespace // ""' < $payload)
@@ -42,6 +41,7 @@ exit_after_diff=$(jq -r '.params.exit_after_diff // "false"' < $payload)
 reuse_values=$(jq -r '.params.reuse_values // "false"' < $payload)
 wait=$(jq -r '.params.wait // 0' < $payload)
 check_is_ready=$(jq -r '.params.check_is_ready // "false"' < $payload)
+kubeconfig_namespace=$(jq -r '.source.kubeconfig_namespace // "false"' < $payload)
 
 if [ -z "$chart" ]; then
   if [[ "$test" == "false" && "$delete" == "false" ]]; then
@@ -54,6 +54,10 @@ if [ -f "$source/$namespace_file" ]; then
   namespace=`cat $source/$namespace_file`
 elif [ -n "$namespace_file" ]; then
   namespace=$namespace_file
+fi
+
+if [ "$kubeconfig_namespace" = "true" ] ; then
+  namespace=$(kubectl config view --minify -ojson | jq -r .contexts[].context.namespace)
 fi
 
 if [ -n "$release_file" ]; then
@@ -108,12 +112,19 @@ set_overridden_values() {
 
 # Find the current revision of a helm release
 current_deployed() {
+  local release="$1"
   $helm_bin history $tls_flag --tiller-namespace $tiller_namespace --max 20 $release | grep "DEPLOYED"
 }
 
 helm_upgrade() {
-  upgrade_args=("upgrade" "$release" $chart_full "--tiller-namespace=$tiller_namespace")
-  non_diff_args=("--install" "--namespace" "$namespace")
+  non_diff_args=("--namespace" "$namespace")
+  if [ "$release" = "" ]; then
+    upgrade_args=("install" $chart_full "--tiller-namespace=$tiller_namespace")
+  else
+    upgrade_args=("upgrade" "$release" $chart_full "--tiller-namespace=$tiller_namespace")
+    non_diff_args+=("--install")
+  fi
+
   if [ -n "$values" ]; then
     for value in $values; do
       upgrade_args+=("-f" "$source/"$value)
@@ -160,7 +171,7 @@ helm_upgrade() {
   helm_args=("${upgrade_args[@]}" "${overridden_args[@]}" "${non_diff_args[@]}")
   helm_echo_args=("${upgrade_args[@]}" "${scrubbed_overridden_args[@]}" "${non_diff_args[@]}")
   helm_diff_args=("${upgrade_args[@]}" "${overridden_args[@]}" "--suppress-secrets" "--allow-unreleased")
-  if [ "$show_diff" = true ] && current_deployed > /dev/null && [ "$devel" != true ]; then
+  if [ "$show_diff" = true ] && current_deployed "$release"> /dev/null && [ "$devel" != true ]; then
     if [ "$tls_enabled" = true ]; then
       echo "helm diff does not support TLS at the present moment."
     else
@@ -265,7 +276,10 @@ else
   echo "Installing $release"
   helm_upgrade
 
-  deployed=$(current_deployed)
+  if [ "$release" = "" ]; then
+    release=$(helm ls -qrd --tiller-namespace $tiller_namespace --max 20 | head -1)
+  fi
+  deployed=$(current_deployed "$release")
   revision=$(echo $deployed | awk '{ print $1 }')
   chart=$(echo $deployed | awk '{ print $8 }')
   echo "Deployed revision $revision of $release"


### PR DESCRIPTION
Allow the concourse-helm-resource to be used in put-only mode with a
kubeconfig file.

This builds off of pr46, but extends it so that there is no need to
configure the resource with the cluster_url (or anything else specified
in the kubeconfig).

Additionally, add a number of additional related controls:

- Get the k8s namespace from the kubeconfig file
- Ability to configure the tiller namespace
- Ability to enable tracing for debugging the resource
- Expose the helm init --wait option
- Ability to specify the kubeconfig path on put.

Together, these features allow us to use the helm resource in conjunction
with the pool resource and the kubernetes resource to:

- Dynamically pick a k8s namespace from a pool, granting exclusive access
- Run a helm-based standalone integration test against a clean environment
  in a dedicated namespace with a dedicated tiller
  - The concourse-helm-resource cleans up anything that may have been in the
    namespace's tiller
  - The concourse-helm-resource installs helm into the namespace
  - The concourse-helm-resource waits for tiller to be ready
  - The concourse-helm-resource installs the chart into the namespace with
    the namespace-specific tiller
- Gather the results (with the kubernetes resource)
- Return the k8s namespace to the pool