### PR TITLE
Make sure /root/.kube always exists

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -30,6 +30,7 @@ setup_kubernetes() {
       elif [ ! -z "$token" ]; then
         kubectl config set-credentials admin --token=$token
       else
+        mkdir -p /root/.kube
         key_path="/root/.kube/key.pem"
         cert_path="/root/.kube/cert.pem"
         echo "$admin_key" | base64 -d > $key_path


### PR DESCRIPTION
With my setup, I get the following error:

```
Initializing kubectl...
/opt/resource/common.sh: line 35: /root/.kube/key.pem: No such file or directory
```

This should fix it.