### PR TITLE
Make sure /root/.config really exists

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -5,10 +5,10 @@ setup_kubernetes() {
   payload=$1
   source=$2
 
+  mkdir -p /root/.kube
   kubeconfig_path=$(jq -r '.params.kubeconfig_path // ""' < $payload)
   absolute_kubeconfig_path="${source}/${kubeconfig_path}"
   if [ -f "$absolute_kubeconfig_path" ]; then
-    mkdir -p /root/.kube
     cp "$absolute_kubeconfig_path" "/root/.kube/config"
   else
     # Setup kubectl


### PR DESCRIPTION
# Description

This PR fix the use of authentication through HTTPS `server_url`, using `server_ca` and `token`.

# Current status

The build break with the following log:
```
Initializing kubectl...
/opt/resource/common.sh: line 29: /root/.kube/ca.pem: No such file or directory
```

# Expectation

Successful build… Or, at least no error at the resource level.