### PR TITLE
 Install dependencies for local charts

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -100,13 +100,6 @@ else
   helm_bin="helm"
 fi
 
-helm_install_local_chart_dependencies() {
-  helm_cmd="helm dependency update $chart_full"
-  helm_echo="helm dependency update $chart_full"
-  echo "Running command $helm_echo"
-  eval "$helm_cmd"
-}
-
 set_overridden_values() {
   while read -r -d '' key && read -r -d '' value && read -r -d '' path && read -r -d '' hidden && read -r -d '' type; do
     if [ -n "$path" ]; then
@@ -191,7 +184,10 @@ helm_upgrade() {
   helm_diff_args=("${upgrade_args[@]}" "${overridden_args[@]}" "--suppress-secrets" "--allow-unreleased")
 
   if [[ -d "$chart_full" ]]; then
-    helm_install_local_chart_dependencies
+    helm_depup_args=("dependency" "update" "$chart_full")
+    helm_depup_echo_args=("dependency" "update" "$chart_full")
+    echo "Running command helm ${helm_depup_echo_args[@]}"
+    $helm_bin "${helm_depup_args[@]}" | tee "$logfile"
   fi
 
   if [ "$show_diff" = true ] && current_deployed "$release"> /dev/null && [ "$devel" != true ]; then

--- a/assets/out
+++ b/assets/out
@@ -100,6 +100,13 @@ else
   helm_bin="helm"
 fi
 
+helm_install_local_chart_dependencies() {
+  helm_cmd="helm dependency update $chart_full"
+  helm_echo="helm dependency update $chart_full"
+  echo "Running command $helm_echo"
+  eval "$helm_cmd"
+}
+
 set_overridden_values() {
   while read -r -d '' key && read -r -d '' value && read -r -d '' path && read -r -d '' hidden && read -r -d '' type; do
     if [ -n "$path" ]; then
@@ -182,6 +189,11 @@ helm_upgrade() {
   helm_args=("${upgrade_args[@]}" "${overridden_args[@]}" "${non_diff_args[@]}")
   helm_echo_args=("${upgrade_args[@]}" "${scrubbed_overridden_args[@]}" "${non_diff_args[@]}")
   helm_diff_args=("${upgrade_args[@]}" "${overridden_args[@]}" "--suppress-secrets" "--allow-unreleased")
+
+  if [[ -d "$chart_full" ]]; then
+    helm_install_local_chart_dependencies
+  fi
+
   if [ "$show_diff" = true ] && current_deployed "$release"> /dev/null && [ "$devel" != true ]; then
     if [ "$tls_enabled" = true ]; then
       echo "helm diff does not support TLS at the present moment."


### PR DESCRIPTION
This makes sure chart dependencies for local charts are downloaded before performing the helm upgrade.

Fixes: https://github.com/linkyard/concourse-helm-resource/issues/51