### PR TITLE
adding the option for reset-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ on the cluster.
 * `show_diff`: *Optional.* Show the diff that is applied if upgrading an existing successful release. Will not be used when `devel` is set. (Default: false)
 * `exit_after_diff`: *Optional.* Show the diff but don't actually install/upgrade. (Default: false)
 * `reuse_values`: *Optional.* When upgrading, reuse the last release's values. (Default: false)
+* `reset_values`: *Optional.* When upgrading, reset the values to the ones built into the chart. (Default: false)
 * `wait`: *Optional.* Allows deploy task to sleep for X seconds before continuing to next task. Allows pods to restart and become stable, useful where dependency between pods exists. (Default: 0)
 * `kubeconfig_path`: *Optional.* File containing a kubeconfig. Overrides source configuration for cluster, token, and admin config.
 

--- a/assets/out
+++ b/assets/out
@@ -41,6 +41,7 @@ recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
 tls_enabled=$(jq -r '.source.tls_enabled // "false"' < $payload)
 exit_after_diff=$(jq -r '.params.exit_after_diff // "false"' < $payload)
 reuse_values=$(jq -r '.params.reuse_values // "false"' < $payload)
+reset_values=$(jq -r '.params.reset_values // "false"' < $payload)
 wait=$(jq -r '.params.wait // 0' < $payload)
 check_is_ready=$(jq -r '.params.check_is_ready // "false"' < $payload)
 kubeconfig_namespace=$(jq -r '.source.kubeconfig_namespace // "false"' < $payload)
@@ -165,6 +166,10 @@ helm_upgrade() {
   if [ "$reuse_values" = true ]; then
     upgrade_args+=("--reuse-values")
     non_diff_args+=("--reuse-values")
+  fi
+  if [ "$reset_values" = true ]; then
+    upgrade_args+=("--reset-values")
+    non_diff_args+=("--reset-values")
   fi
 
   logfile="/tmp/log"


### PR DESCRIPTION
If you want helm to reset the values of your deployment you need to use --reset-values.   This is good to combat manual changes to deployments with a redeploy.  This enables that feature in this resource.

let me know if i missed something