### PR TITLE
Escape override_values

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ on the cluster.
   the file in that path. A `hide: true` parameter ensures that the value is not logged and instead replaced with `***HIDDEN***`.
   A `type: string` parameter makes sure Helm always treats the value as a string (uses the `--set-string` option to Helm; useful if the value varies
   and may look like a number, eg. if it's a Git commit hash).
-  An `verbatim: true` parameter escapes backslashes so the value is passed as-is to the Helm chart (useful for `((credentials))`).
+  A `verbatim: true` parameter escapes backslashes so the value is passed as-is to the Helm chart (useful for `((credentials))`).
   The default behaviour of backslashes in `--set` is to quote the next character so `val\ue` is treated as `value` by Helm.
 * `token_path`: *Optional.* Path to file containing the bearer token for Kubernetes.  This, 'token' or `admin_key`/`admin_cert` are required if `cluster_url` is https.
 * `version`: *Optional* Chart version to deploy, can be a file or a value. Only applies if `chart` is not a file.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ on the cluster.
   the file in that path. A `hide: true` parameter ensures that the value is not logged and instead replaced with `***HIDDEN***`.
   A `type: string` parameter makes sure Helm always treats the value as a string (uses the `--set-string` option to Helm; useful if the value varies
   and may look like a number, eg. if it's a Git commit hash).
+  An `verbatim: true` parameter escapes backslashes so the value is passed as-is to the Helm chart (useful for `((credentials))`).
+  The default behaviour of backslashes in `--set` is to quote the next character so `val\ue` is treated as `value` by Helm.
 * `token_path`: *Optional.* Path to file containing the bearer token for Kubernetes.  This, 'token' or `admin_key`/`admin_cert` are required if `cluster_url` is https.
 * `version`: *Optional* Chart version to deploy, can be a file or a value. Only applies if `chart` is not a file.
 * `delete`: *Optional.* Deletes the release instead of installing it. Requires the `name`. (Default: false)

--- a/assets/out
+++ b/assets/out
@@ -93,9 +93,13 @@ else
 fi
 
 set_overridden_values() {
-  while read -r -d '' key && read -r -d '' value && read -r -d '' path && read -r -d '' hidden && read -r -d '' type; do
+  while read -r -d '' key && read -r -d '' value && read -r -d '' path && read -r -d '' hidden && read -r -d '' type && read -r -d '' verbatim; do
     if [ -n "$path" ]; then
       value="$(< "$source/$path")"
+    fi
+
+    if [ "$verbatim" != 'false' ]; then
+      value="${value/\\/\\\\}"
     fi
 
     scrubbed_value="$value"
@@ -110,7 +114,7 @@ set_overridden_values() {
 
     overridden_args+=("$helm_set_opt" "$key=$value")
     scrubbed_overridden_args+=("$helm_set_opt" "$key=$scrubbed_value")
-  done < <(jq -j '.params.override_values[]? | if .key and (.value or .path) then (.key, .value // "", .path // "", .hide // false, .type) else empty end | tostring + "\u0000"'  < $payload)
+  done < <(jq -j '.params.override_values[]? | if .key and (.value or .path) then (.key, .value // "", .path // "", .hide // false, .type, .verbatim // false) else empty end | tostring + "\u0000"'  < $payload)
 }
 
 # Find the current revision of a helm release


### PR DESCRIPTION
Fixes #130

Add a `verbatim: true` parameter to `override_values` to escape backslashes passed to `helm --set`.