### PR TITLE
Add support for --atomic flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ on the cluster.
 * `wait_until_ready`: *Optional.* Set to the number of seconds it should wait until all the resources in
     the chart are ready. (Default: `0` which means don't wait).
 * `check_is_ready`: *Optional.* Requires that `wait_until_ready` is set to Default. Applies --wait without timeout. (Default: false)
+* `atomic`: *Optional.* This flag will cause failed installs to purge the release, and failed upgrades to rollback to the previous release. (Default: false)
 * `recreate_pods`: *Optional.* This flag will cause all pods to be recreated when upgrading. (Default: false)
 * `show_diff`: *Optional.* Show the diff that is applied if upgrading an existing successful release. Will not be used when `devel` is set. (Default: false)
 * `exit_after_diff`: *Optional.* Show the diff but don't actually install/upgrade. (Default: false)

--- a/assets/out
+++ b/assets/out
@@ -34,6 +34,7 @@ delete=$(jq -r '.params.delete // "false"' < $payload)
 test=$(jq -r '.params.test // "false"' < $payload)
 purge=$(jq -r '.params.purge // "false"' < $payload)
 devel=$(jq -r '.params.devel // "false"' < $payload)
+atomic=$(jq -r '.params.atomic // "false"' < $payload)
 recreate_pods=$(jq -r '.params.recreate_pods // "false"' < $payload)
 force=$(jq -r '.params.force // "false"' < $payload)
 show_diff=$(jq -r '.params.show_diff // "false"' < $payload)
@@ -160,6 +161,9 @@ helm_upgrade() {
       version=$(cat $source/$version)
     fi
     upgrade_args+=("--version" "$version")
+  fi
+  if [ "$atomic" = true ]; then
+    non_diff_args+=("--atomic")
   fi
   if [ "$recreate_pods" = true ]; then
     non_diff_args+=("--recreate-pods")


### PR DESCRIPTION
Behavior of the `--atomic` flag:

- Failed installs will purge the release
- Failed upgrades will rollback to the previous release

Exists in Helm 2.14.x and upward.

https://v2-14-0.helm.sh/docs/helm/#helm-install
https://v2-14-0.helm.sh/docs/helm/#helm-upgrade