### PR TITLE
Expand env variables such as metadata resource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/helm:2.14.3
 LABEL maintainer "mario.siegenthaler@linkyard.ch"
 
-RUN apk add --update --upgrade --no-cache jq bash curl git
+RUN apk add --update --upgrade --no-cache jq bash curl git gettext libintl
 
 ENV KUBERNETES_VERSION 1.16.3
 RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/amd64/kubectl; \

--- a/assets/out
+++ b/assets/out
@@ -52,7 +52,6 @@ if [ -z "$chart" ]; then
     exit 1
   fi
 fi
-
 if [ -f "$source/$namespace_file" ]; then
   namespace=`cat $source/$namespace_file`
 elif [ -n "$namespace_file" ]; then
@@ -72,6 +71,9 @@ if [ -n "$release_file" ]; then
 else
   release=$(jq -r '.source.release // ""' < $payload)
 fi
+
+# Expand env variables such as resource metadata (see https://concourse-ci.org/implementing-resource-types.html#resource-metadata)
+release=$(echo -n "$release" | envsubst)
 
 if [[ "$chart" == *.tgz ]] || [[ -d "$source/$chart" ]]; then
   # it's a file/directory


### PR DESCRIPTION
Allow expanding env variables such as Concourse metadata resource (see https://concourse-ci.org/implementing-resource-types.html#resource-metadata)