### PR TITLE
Updating Helm to 2.16.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine/helm:2.16.1
+FROM alpine/helm:2.16.4
 LABEL maintainer "mario.siegenthaler@linkyard.ch"
 
 RUN apk add --update --upgrade --no-cache jq bash curl git gettext libintl


### PR DESCRIPTION
Doing this because Helm 2.16.4 has a pretty important fix for indeterministic Helm upgrade errors.

See. https://github.com/helm/helm/issues/6031#issuecomment-570068395

This is live on Helm 2.16.4 https://github.com/helm/helm/releases/tag/v2.16.4