### PR TITLE
Limit helm history and list commands to one revision

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -127,7 +127,7 @@ set_overridden_values() {
 # Find the current revision of a helm release
 current_deployed() {
   local release="$1"
-  $helm_bin history $tls_flag --tiller-namespace $tiller_namespace --max 20 $release | grep "DEPLOYED"
+  $helm_bin history $tls_flag --tiller-namespace $tiller_namespace --max 1 $release | grep "DEPLOYED"
 }
 
 helm_upgrade() {
@@ -306,7 +306,7 @@ else
   helm_upgrade
 
   if [ "$release" = "" ]; then
-    release=$(helm ls -qrd --tiller-namespace $tiller_namespace --max 20 | head -1)
+    release=$(helm ls -qrd --tiller-namespace $tiller_namespace --max 1 | head -1)
   fi
   deployed=$(current_deployed "$release")
   revision=$(echo $deployed | awk '{ print $1 }')


### PR DESCRIPTION
Closes https://github.com/linkyard/concourse-helm-resource/issues/129.

In the instance where `helm history` or `helm ls` is called there is really no reason to retrieve the last 20 revisions. Especially because the only purpose of executing these commands is to parse and obtain the `release` name. 

Furthermore, in situations where a release may contain a large amount of data we can hit the gRPC size limit as outlined in the issue.